### PR TITLE
provider/nats: add JetStream support, refactor shared connect helper

### DIFF
--- a/docs/provider/nats.md
+++ b/docs/provider/nats.md
@@ -12,10 +12,18 @@ The NATS client provides a simple interface for connecting to NATS servers, publ
 - Request/Reply patterns
 - Queue groups for distributing message processing
 - JSON serialization for structured messages
+- JetStream persistent streams via dedicated `JSProducer` / `JSConsumer` types
+  (see [JetStream](#jetstream))
 
 ## Configuration
 
 ### Producer Configuration
+
+The effective shape below is flattened for readability. In the actual Go
+type, `Password`/`Token` come from the embedded
+`secure.DefaultCredentialConfig`, the TLS fields come from the embedded
+`tls.ClientConfig`, and the connection-tuning fields come from the embedded
+`ProducerOptions` struct.
 
 ```go
 type ProducerConfig struct {
@@ -23,15 +31,16 @@ type ProducerConfig struct {
 	Subject  string // Default subject to publish to
 	AuthType string // Authentication type: "none", "basic", "token"
 	Username string // Username for basic auth
-	Password string // Password for basic auth
-	Token    string // Auth token
+	Password string // Password for basic auth (embedded secure.DefaultCredentialConfig)
+	Token    string // Auth token (embedded secure.DefaultCredentialConfig)
 
-	// Connection settings
+	// Connection settings (embedded ProducerOptions)
 	PingInterval uint // PingInterval in seconds, defaults to 2 minutes
 	MaxPingsOut  uint // MaxPingsOut value, defaults to 2
 	Timeout      uint // Connection timeout in milliseconds, defaults to 2000
 	DrainTimeout uint // Drain timeout in milliseconds, defaults to 30000
-	// TLS Configuration
+
+	// TLS Configuration (embedded tls.ClientConfig)
 	TLSEnabled            bool   // Enable TLS
 	TLSInsecureSkipVerify bool   // Skip certificate verification
 	TLSCertFile           string // Client certificate file path
@@ -42,22 +51,31 @@ type ProducerConfig struct {
 
 ### Consumer Configuration
 
+As with `ProducerConfig`, the shape below is flattened for readability. In
+the actual Go type, `Password`/`Token` come from the embedded
+`secure.DefaultCredentialConfig`, the TLS fields come from the embedded
+`tls.ClientConfig`, and `QueueGroup` together with the connection-tuning
+fields come from the embedded `ConsumerOptions` struct. To set a queue group
+you assign `cfg.ConsumerOptions = nats.ConsumerOptions{QueueGroup: "..."}`
+(see the example below).
+
 ```go
 type ConsumerConfig struct {
 	URL        string // NATS server URL (e.g., "nats://localhost:4222")
 	Subject    string // Subject pattern to subscribe to
 	AuthType   string // Authentication type: "none", "basic", "token"
 	Username   string // Username for basic auth
-	Password   string // Password for basic auth
-	Token      string // Auth token
-	QueueGroup string // Queue group for distributing messages among subscribers
+	Password   string // Password for basic auth (embedded secure.DefaultCredentialConfig)
+	Token      string // Auth token (embedded secure.DefaultCredentialConfig)
+	QueueGroup string // Queue group (embedded ConsumerOptions.QueueGroup)
 
-	// Connection settings
+	// Connection settings (embedded ConsumerOptions)
 	PingInterval uint // PingInterval in seconds, defaults to 2 minutes
 	MaxPingsOut  uint // MaxPingsOut value, defaults to 2
 	Timeout      uint // Connection timeout in milliseconds, defaults to 2000
 	DrainTimeout uint // Drain timeout in milliseconds, defaults to 30000
-	// TLS Configuration
+
+	// TLS Configuration (embedded tls.ClientConfig)
 	TLSEnabled            bool   // Enable TLS
 	TLSInsecureSkipVerify bool   // Skip certificate verification
 	TLSCertFile           string // Client certificate file path
@@ -198,6 +216,18 @@ func main() {
 
 ### Synchronous Message Consumption
 
+`NextMsg` returns the upstream `nats.ErrTimeout` sentinel when the timeout
+expires without a message arriving. Because the Blueprint provider package
+is typically imported under the alias `nats`, the upstream package has to
+be imported under a different alias to reach its error constants:
+
+```go
+import (
+    natsio "github.com/nats-io/nats.go"
+    "github.com/oddbit-project/blueprint/provider/nats"
+)
+```
+
 ```go
 // Subscribe synchronously
 sub, err := consumer.SubscribeSync()
@@ -209,7 +239,7 @@ if err != nil {
 // Get next message with timeout
 msg, err := consumer.NextMsg(sub, time.Second*5)
 if err != nil {
-	if err == nats.ErrTimeout {
+	if errors.Is(err, natsio.ErrTimeout) {
         logger.Info("No message received within timeout", nil)
     } else {
         logger.Error(err, "Failed to get next message", nil)
@@ -267,3 +297,351 @@ config := &nats.ProducerConfig{
 	TLSCaFile:             "/path/to/ca.crt",
 }
 ```
+
+## JetStream
+
+JetStream is NATS' built-in persistent streaming layer. The Blueprint NATS
+provider exposes JetStream through two dedicated types that are independent
+from the core `Producer`/`Consumer`: `JSProducer` publishes to a stream and
+waits for server acks, `JSConsumer` reads from a stream with explicit
+acknowledgements and automatic redelivery on failure.
+
+JetStream requires `nats-server` to be started with the `-js` flag (or
+`jetstream: enabled` in the server configuration).
+
+### Configuration
+
+The JetStream types share a common connection config (`JSConnectionConfig`)
+with the same URL/auth/TLS fields used by the core types.
+
+```go
+type JSConnectionConfig struct {
+    URL          string // NATS server URL
+    AuthType     string // "none" | "basic" | "token"
+    Username     string // for basic auth
+    // embedded secure.DefaultCredentialConfig: Password / Token
+    ClientName   string // defaults to "natsJSProducer" / "natsJSConsumer"
+    // embedded tls.ClientConfig: TLSEnabled, TLSCertFile, etc.
+    PingInterval uint   // seconds
+    MaxPingsOut  uint
+    Timeout      uint   // milliseconds
+}
+```
+
+#### Producer configuration
+
+```go
+type JSProducerConfig struct {
+    JSConnectionConfig
+    Subject          string       // default publish subject
+    Stream           StreamConfig // stream to target
+    AutoCreateStream bool         // create-or-update stream on startup
+}
+
+type StreamConfig struct {
+    Name        string
+    Description string
+    Subjects    []string       // e.g. ["orders.>"]
+    Retention   string         // "limits" | "interest" | "workqueue"
+    Storage     string         // "file" | "memory"
+    MaxAge      time.Duration
+    MaxMsgs     int64
+    MaxBytes    int64
+    Replicas    int
+    Duplicates  time.Duration
+
+    // Native escape hatch: when set, all other StreamConfig fields are
+    // ignored and the supplied jetstream.StreamConfig is used verbatim.
+    Native *jetstream.StreamConfig
+}
+```
+
+`AutoCreateStream` defaults to `false` for production safety — in that mode
+the producer looks the stream up at startup and fails if it does not exist.
+When `AutoCreateStream` is `true`, the provider will `CreateOrUpdateStream`
+on startup, which is convenient for development and tests.
+
+#### Consumer configuration
+
+```go
+type JSConsumerConfig struct {
+    JSConnectionConfig
+    StreamName    string // required; stream must already exist
+    Durable       string // durable name; leave empty for ephemeral
+    ConsumerName  string // optional explicit name
+    FilterSubject string // optional subject filter under the stream
+
+    AckPolicy     string        // "explicit" (default) | "all" | "none"
+    AckWait       time.Duration
+    MaxDeliver    int
+    MaxAckPending int
+    DeliverPolicy string        // "all" (default) | "last" | "new"
+
+    // Native escape hatch: when set, all other policy fields are ignored.
+    Native *jetstream.ConsumerConfig
+}
+```
+
+Both config types expose a `Validate()` method that is called automatically
+by the constructors before any network round-trips. Invalid policy strings
+return `ErrInvalidAckPolicy` / `ErrInvalidDeliverPolicy` / `ErrInvalidRetention`
+/ `ErrInvalidStorage`; missing required fields return `ErrMissingJSURL`,
+`ErrMissingStreamName`, or `ErrMissingProducerTopic`.
+
+### Producer usage
+
+```go
+package main
+
+import (
+    "context"
+    "time"
+
+    "github.com/oddbit-project/blueprint/log"
+    "github.com/oddbit-project/blueprint/provider/nats"
+)
+
+func main() {
+    cfg := &nats.JSProducerConfig{
+        JSConnectionConfig: nats.JSConnectionConfig{
+            URL:      "nats://localhost:4222",
+            AuthType: nats.AuthTypeNone,
+        },
+        Subject: "orders.created",
+        Stream: nats.StreamConfig{
+            Name:     "ORDERS",
+            Subjects: []string{"orders.>"},
+            Storage:  "file",
+            MaxAge:   24 * time.Hour,
+            Replicas: 1,
+        },
+        AutoCreateStream: true,
+    }
+
+    logger := log.New("orders-producer")
+
+    producer, err := nats.NewJSProducer(cfg, logger)
+    if err != nil {
+        logger.Fatal(err, "Failed to create JetStream producer", nil)
+    }
+    defer producer.Disconnect()
+
+    ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+    defer cancel()
+
+    // Publish and wait for server ack
+    ack, err := producer.Publish(ctx, []byte(`{"id":"o-1"}`))
+    if err != nil {
+        logger.Error(err, "Publish failed", nil)
+        return
+    }
+    logger.Info("Published", log.KV{
+        "stream":   ack.Stream,
+        "sequence": ack.Sequence,
+    })
+
+    // Publish JSON helper
+    _, _ = producer.PublishJSON(ctx, map[string]any{"id": "o-2", "total": 99.0})
+
+    // Publish to an explicit subject under the stream
+    _, _ = producer.PublishMsg(ctx, "orders.updated", []byte(`{"id":"o-1"}`))
+
+    // Async publish: returns a future whose Ok()/Err() channels signal the
+    // eventual ack without blocking the caller.
+    fut, err := producer.PublishAsync(ctx, "orders.created", []byte(`{"id":"o-3"}`))
+    if err == nil {
+        select {
+        case <-fut.Ok():
+        case err := <-fut.Err():
+            logger.Error(err, "Async publish failed", nil)
+        case <-time.After(2 * time.Second):
+            logger.Error(nil, "Async publish timed out", nil)
+        }
+    }
+}
+```
+
+### Consumer usage
+
+`JSConsumer.Consume` starts continuous delivery; the handler is invoked once
+per message. If the handler returns `nil` the message is automatically
+acknowledged; if it returns a non-nil error the message is `Nak`'d and
+redelivered (up to `MaxDeliver` times). Only one concurrent `Consume` session
+is allowed per consumer — calling `Consume` twice returns `ErrAlreadyConsuming`.
+
+```go
+package main
+
+import (
+    "context"
+    "os"
+    "os/signal"
+    "syscall"
+    "time"
+
+    "github.com/oddbit-project/blueprint/log"
+    "github.com/oddbit-project/blueprint/provider/nats"
+)
+
+func main() {
+    cfg := &nats.JSConsumerConfig{
+        JSConnectionConfig: nats.JSConnectionConfig{
+            URL:      "nats://localhost:4222",
+            AuthType: nats.AuthTypeNone,
+        },
+        StreamName:    "ORDERS",
+        Durable:       "orders-worker",
+        FilterSubject: "orders.created",
+        AckPolicy:     "explicit",
+        AckWait:       30 * time.Second,
+        MaxDeliver:    5,
+        MaxAckPending: 256,
+        DeliverPolicy: "all",
+    }
+
+    logger := log.New("orders-worker")
+
+    consumer, err := nats.NewJSConsumer(cfg, logger)
+    if err != nil {
+        logger.Fatal(err, "Failed to create JetStream consumer", nil)
+    }
+    defer consumer.Disconnect()
+
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+
+    // Consume returns immediately; delivery runs in the background. The
+    // handler receives the same ctx that was passed to Consume, so it can
+    // honour cancellation from the outer scope.
+    err = consumer.Consume(ctx, func(hctx context.Context, msg nats.JSMessage) error {
+        logger.Info("Received", log.KV{
+            "subject": msg.Subject(),
+            "size":    len(msg.Data()),
+        })
+        // Returning nil auto-Acks; returning a non-nil error auto-Naks.
+        return processOrder(hctx, msg.Data())
+    })
+    if err != nil {
+        logger.Fatal(err, "Consume failed", nil)
+    }
+
+    // Block on SIGINT/SIGTERM. When a signal arrives cancel() stops the
+    // consume session via the watcher goroutine, and the deferred
+    // Disconnect() drains the connection.
+    sigCh := make(chan os.Signal, 1)
+    signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+    <-sigCh
+}
+
+func processOrder(ctx context.Context, _ []byte) error { return ctx.Err() }
+```
+
+#### Pull-style one-off fetch
+
+For batch or polling workloads, use `Fetch` instead of `Consume`:
+
+```go
+msgs, err := consumer.Fetch(50, 2*time.Second)
+if err != nil && len(msgs) == 0 {
+    logger.Error(err, "Fetch failed", nil)
+    return
+}
+for _, m := range msgs {
+    if err := processOrder(m.Data()); err != nil {
+        _ = m.Nak()
+        continue
+    }
+    _ = m.Ack()
+}
+```
+
+Note that `Fetch` may return a non-nil slice **and** a non-nil error
+simultaneously when the batch was interrupted mid-delivery. Handle both.
+
+### Manual acknowledgement control
+
+`JSMessage` exposes the full ack API when automatic ack-on-return is not
+flexible enough. For example, signalling "still working" on long-running
+handlers:
+
+```go
+err := consumer.Consume(ctx, func(ctx context.Context, msg nats.JSMessage) error {
+    ticker := time.NewTicker(10 * time.Second)
+    defer ticker.Stop()
+
+    done := make(chan error, 1)
+    go func() { done <- longRunningWork(msg.Data()) }()
+
+    for {
+        select {
+        case err := <-done:
+            return err // auto-Ack on nil, auto-Nak on error
+        case <-ticker.C:
+            _ = msg.InProgress() // extend ack-wait
+        case <-ctx.Done():
+            _ = msg.Nak()
+            return ctx.Err()
+        }
+    }
+})
+```
+
+Other available methods: `msg.Ack()`, `msg.Nak()`, `msg.Term()` (permanent
+reject — no redelivery), `msg.Metadata()` (sequence, delivery count,
+timestamp), and `msg.Raw()` (the underlying `jetstream.Msg` for advanced
+use cases).
+
+### Managing streams outside the producer
+
+The recommended pattern for production deployments is:
+
+1. Provision streams at deploy time with a bootstrap `JSProducer` configured
+   with `AutoCreateStream: true` — for example in a migration job or a
+   one-shot CLI tool.
+2. Run application producers with `AutoCreateStream: false` and a
+   name-only `StreamConfig{Name: "..."}`. The producer will look the
+   stream up at startup and fail if it does not exist, which catches
+   misconfigured deployments early instead of silently recreating a stream
+   with different parameters.
+
+`EnsureStream(ctx, js, cfg)` is exposed as a helper for code that holds its
+own `jetstream.JetStream` handle (for example, a deploy tool or an
+integration test harness):
+
+```go
+streamCfg := nats.StreamConfig{
+    Name:     "ORDERS",
+    Subjects: []string{"orders.>"},
+    Storage:  "file",
+    Replicas: 1,
+}
+stream, err := nats.EnsureStream(ctx, js, streamCfg)
+if err != nil {
+    return err
+}
+_ = stream // jetstream.Stream handle for further inspection
+```
+
+If `StreamConfig.Native` is set, the other fields on `StreamConfig` are
+ignored and the supplied `jetstream.StreamConfig` is passed through verbatim.
+This is the escape hatch for fields not exposed on the friendly wrapper (for
+example `Placement`, `Sources`, `SubjectTransform`).
+
+### Error constants
+
+JetStream-specific error sentinels (all declared in `provider/nats/js_common.go`):
+
+| Constant | Meaning |
+|---|---|
+| `ErrMissingJSURL` | `JSConnectionConfig.URL` was empty |
+| `ErrMissingStreamName` | `JSConsumerConfig.StreamName` / `StreamConfig.Name` was empty when required |
+| `ErrJSNoConsumer` | Consumer handle was not initialized |
+| `ErrAlreadyConsuming` | `Consume()` called while a session is already active |
+| `ErrInvalidAckPolicy` | `AckPolicy` was not `""`, `"explicit"`, `"all"`, or `"none"` |
+| `ErrInvalidDeliverPolicy` | `DeliverPolicy` was not `""`, `"all"`, `"last"`, or `"new"` |
+| `ErrInvalidRetention` | `StreamConfig.Retention` was not `""`, `"limits"`, `"interest"`, or `"workqueue"` |
+| `ErrInvalidStorage` | `StreamConfig.Storage` was not `""`, `"file"`, or `"memory"` |
+
+The existing core-NATS sentinels (`ErrMissingProducerTopic`, `ErrInvalidAuthType`,
+`ErrNilConfig`, `ErrConsumerClosed`, `ErrProducerClosed`) are also returned by
+the JetStream paths where appropriate.

--- a/provider/nats/CHANGELOG.md
+++ b/provider/nats/CHANGELOG.md
@@ -4,13 +4,81 @@ All notable changes to the Blueprint NATS provider will be documented in this fi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+- JetStream support via new `JSProducer` and `JSConsumer` types
+  - `JSProducerConfig` with optional `AutoCreateStream` (defaults to false) and
+    up-front `Validate()`
+  - `StreamConfig` wrapper with friendly JSON tags and a `Native` escape hatch
+    for advanced `jetstream.StreamConfig` overrides
+  - `JSConsumerConfig` with pull-based `Consume` (auto Ack/Nak on handler
+    result) and one-off `Fetch` APIs, plus up-front `Validate()`
+  - `JSMessage` wrapper exposing `Ack/Nak/InProgress/Term/Metadata`, with a
+    `Native` escape hatch on consumer config for full `jetstream.ConsumerConfig`
+    access
+  - `EnsureStream` helper for create-or-update outside of producer startup
+  - New error constants: `ErrMissingJSURL`, `ErrMissingStreamName`,
+    `ErrJSNoConsumer`, `ErrAlreadyConsuming`, `ErrInvalidAckPolicy`,
+    `ErrInvalidDeliverPolicy`, `ErrInvalidRetention`, `ErrInvalidStorage`
+- Integration tests covering publish/consume, fetch, redelivery, explicit
+  stream lookup, double-Consume rejection, and Disconnect-while-consuming
+  (testcontainer now runs with `-js`)
+- Unit tests for `JSConsumerConfig.Validate` and `JSProducerConfig.Validate`
+
+### Changed
+- Extracted shared NATS connection logic into an internal `connect()` helper;
+  `NewConsumer` and `NewProducer` now delegate to it. No API changes to the
+  existing public types.
+- **Core `NewConsumer` token-auth fix (behavior change):** previously
+  `ConsumerConfig` with `AuthType: "token"` silently sent an empty token
+  because the credential was only loaded for the `basic` auth type. The
+  shared connect helper now loads credentials for both `basic` and `token`
+  on the consumer side, matching the long-standing producer behavior. If you
+  were inadvertently relying on the broken empty-token path (e.g. by also
+  embedding credentials in the URL), review your `ConsumerConfig` auth
+  setup.
+- `JSProducer.PublishAsync` now takes a `context.Context` as its first
+  parameter so callers can fail fast on an already-cancelled context
+  (consistent with `Publish`/`PublishMsg`). The underlying jetstream async
+  publish API takes no context; callers still need to select on the
+  `PubAckFuture` channel for post-dispatch cancellation.
+- Renamed internal constant `DefaultJSPublishTimeout` →
+  `DefaultJSSetupTimeout` (it bounds stream/consumer setup round-trips, not
+  publish operations).
+
+### Fixed
+- `JSConsumer.Consume` used to silently overwrite its internal consume-context
+  reference when called twice, leaking the first session and causing the
+  first context's cancellation to stop the wrong consume context. It now
+  returns `ErrAlreadyConsuming` on re-entry and correctly associates each
+  watcher goroutine with the consume context it created.
+- `JSConsumer.Consume` used to leak its watcher goroutine when the caller
+  passed a non-cancellable context and then called `Disconnect()`. Disconnect
+  now signals an internal stop channel so the goroutine always exits.
+- `JSConsumer.Disconnect` is now idempotent; repeated calls are no-ops
+  instead of double-draining.
+- `buildJSConsumerConfig` no longer returns `ErrInvalidAuthType` for an
+  invalid `AckPolicy` value (now returns `ErrInvalidAckPolicy`), and
+  `DeliverPolicy` now rejects unknown values with `ErrInvalidDeliverPolicy`
+  instead of silently accepting them.
+
 ## [v0.8.0]
 
 ### Added
 - Initial release of NATS provider as independent module
 - Lightweight messaging capabilities
 - Publisher and subscriber functionality
-- JetStream support for persistent messaging
+- Configuration management
+- Integration tests with testcontainers
+- Comprehensive error handling
+
+## [v0.8.0]
+
+### Added
+- Initial release of NATS provider as independent module
+- Lightweight messaging capabilities
+- Publisher and subscriber functionality
 - Configuration management
 - Integration tests with testcontainers
 - Comprehensive error handling

--- a/provider/nats/connection.go
+++ b/provider/nats/connection.go
@@ -1,0 +1,99 @@
+package nats
+
+import (
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/oddbit-project/blueprint/crypt/secure"
+	tlsProvider "github.com/oddbit-project/blueprint/provider/tls"
+)
+
+// connectParams is the internal, shared set of inputs needed to open a NATS
+// connection. Both the core-NATS consumer/producer and the JetStream clients
+// build one of these and call connect().
+type connectParams struct {
+	URL      string
+	Name     string
+	AuthType string
+	Username string
+	Cred     secure.DefaultCredentialConfig
+	TLS      tlsProvider.ClientConfig
+
+	PingInterval uint // seconds
+	MaxPingsOut  uint
+	Timeout      uint // milliseconds
+}
+
+// connect opens a NATS connection using the shared parameters. It transparently
+// handles secure credential loading for AuthTypeBasic/Token and TLS wiring.
+// The caller is responsible for logging; connect only returns errors.
+//
+// Credential hygiene note: the secure.Credential buffer is Clear'd before
+// return, but by that point the plaintext has been copied into Go strings
+// (opts.Password / opts.Token) and retained internally by nats.Conn. Go
+// strings are immutable and cannot be zeroed, so the Clear() call is a
+// best-effort reduction of the plaintext window rather than a guarantee.
+// Fully eliminating the plaintext exposure would require using a callback-
+// based auth mechanism on nats.Options which is not currently wired up.
+func connect(p connectParams) (*nats.Conn, error) {
+	var (
+		credential *secure.Credential
+		password   string
+		err        error
+	)
+
+	switch p.AuthType {
+	case AuthTypeBasic, AuthTypeToken:
+		key, kerr := secure.GenerateKey()
+		if kerr != nil {
+			return nil, kerr
+		}
+		if credential, err = secure.CredentialFromConfig(p.Cred, key, true); err != nil {
+			return nil, err
+		}
+		// Ensure the encrypted credential buffer is Clear'd on every return
+		// path (including TLS errors and panics), not just the normal one.
+		defer credential.Clear()
+		if password, err = credential.Get(); err != nil {
+			return nil, err
+		}
+	}
+
+	opts := nats.Options{
+		Url:            p.URL,
+		AllowReconnect: true,
+		MaxReconnect:   DefaultConnectRetry,
+		ReconnectWait:  DefaultTimeout,
+		Name:           p.Name,
+	}
+
+	switch p.AuthType {
+	case AuthTypeBasic:
+		opts.User = p.Username
+		opts.Password = password
+	case AuthTypeToken:
+		opts.Token = password
+	}
+
+	if tls, terr := p.TLS.TLSConfig(); terr != nil {
+		return nil, terr
+	} else if tls != nil {
+		opts.TLSConfig = tls
+	}
+
+	if p.PingInterval > 0 {
+		opts.PingInterval = time.Duration(p.PingInterval) * time.Second
+	}
+	if p.MaxPingsOut > 0 {
+		opts.MaxPingsOut = int(p.MaxPingsOut)
+	}
+	if p.Timeout > 0 {
+		opts.Timeout = time.Duration(p.Timeout) * time.Millisecond
+	}
+
+	conn, err := opts.Connect()
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
+}

--- a/provider/nats/consumer.go
+++ b/provider/nats/consumer.go
@@ -92,77 +92,35 @@ func NewConsumer(cfg *ConsumerConfig, logger *log.Logger) (*Consumer, error) {
 		return nil, err
 	}
 
-	var key []byte
-	var credential *secure.Credential
-	var password string
-	var err error
-
-	if cfg.AuthType == AuthTypeBasic {
-		key, err = secure.GenerateKey()
-		if err != nil {
-			return nil, err
-		}
-		if credential, err = secure.CredentialFromConfig(cfg.DefaultCredentialConfig, key, true); err != nil {
-			return nil, err
-		}
-		password, err = credential.Get()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	if cfg.ConsumerName == "" {
 		cfg.ConsumerName = "natsConsumer"
 	}
-
-	// Configure connection options
-	opts := nats.Options{
-		Url:            cfg.URL,
-		AllowReconnect: true,
-		MaxReconnect:   DefaultConnectRetry,
-		ReconnectWait:  DefaultTimeout,
-		Name:           cfg.ConsumerName,
-	}
-
-	// Apply authentication
-	switch cfg.AuthType {
-	case AuthTypeBasic:
-		opts.User = cfg.Username
-		opts.Password = password
-	case AuthTypeToken:
-		opts.Token = password
-	}
-
-	// Apply TLS settings
-	if tls, err := cfg.TLSConfig(); err != nil {
-		return nil, err
-	} else if tls != nil {
-		opts.TLSConfig = tls
-	}
-
-	// Apply additional options
-	cfg.ConsumerOptions.ApplyOptions(&opts)
 
 	// Create logger if not provided
 	if logger == nil {
 		logger = NewConsumerLogger(cfg.Subject, cfg.QueueGroup)
 	} else {
-		ConsumerLogger(logger, cfg.Subject, cfg.QueueGroup)
+		logger = ConsumerLogger(logger, cfg.Subject, cfg.QueueGroup)
 	}
 
-	// Connect to NATS
-	conn, err := opts.Connect()
+	// Connect to NATS via shared helper
+	conn, err := connect(connectParams{
+		URL:          cfg.URL,
+		Name:         cfg.ConsumerName,
+		AuthType:     cfg.AuthType,
+		Username:     cfg.Username,
+		Cred:         cfg.DefaultCredentialConfig,
+		TLS:          cfg.ClientConfig,
+		PingInterval: cfg.ConsumerOptions.PingInterval,
+		MaxPingsOut:  cfg.ConsumerOptions.MaxPingsOut,
+		Timeout:      cfg.ConsumerOptions.Timeout,
+	})
 	if err != nil {
 		logger.Error(err, "Failed to connect to NATS", log.KV{
 			"url":     cfg.URL,
 			"subject": cfg.Subject,
 		})
 		return nil, err
-	}
-
-	// Clean up credentials from memory if used
-	if credential != nil {
-		credential.Clear()
 	}
 
 	return &Consumer{

--- a/provider/nats/integration_test.go
+++ b/provider/nats/integration_test.go
@@ -55,6 +55,7 @@ func (s *NATSIntegrationTestSuite) SetupSuite() {
 		"nats:2.10-alpine",
 		nats.WithUsername("testuser"),
 		nats.WithPassword("testpassword"),
+		testcontainers.WithCmdArgs("-js"), // enable JetStream for JS tests
 		testcontainers.WithWaitStrategy(
 			wait.ForListeningPort("4222/tcp").WithStartupTimeout(60*time.Second),
 		),

--- a/provider/nats/js_common.go
+++ b/provider/nats/js_common.go
@@ -1,0 +1,155 @@
+package nats
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/oddbit-project/blueprint/crypt/secure"
+	tlsProvider "github.com/oddbit-project/blueprint/provider/tls"
+	"github.com/oddbit-project/blueprint/utils"
+)
+
+const (
+	ErrMissingJSURL         = utils.Error("Missing JetStream URL")
+	ErrMissingStreamName    = utils.Error("Missing JetStream stream name")
+	ErrJSNoConsumer         = utils.Error("JetStream consumer not initialized")
+	ErrAlreadyConsuming     = utils.Error("JetStream consumer is already consuming")
+	ErrInvalidAckPolicy     = utils.Error("Invalid JetStream ack policy")
+	ErrInvalidDeliverPolicy = utils.Error("Invalid JetStream deliver policy")
+	ErrInvalidRetention     = utils.Error("Invalid JetStream retention policy")
+	ErrInvalidStorage       = utils.Error("Invalid JetStream storage type")
+
+	// DefaultJSSetupTimeout bounds stream/consumer lookup and create-or-update
+	// operations performed during client construction. Publish operations use
+	// the caller-supplied context.
+	DefaultJSSetupTimeout = 10 * time.Second
+)
+
+// JSConnectionConfig holds the fields needed to open a NATS connection for
+// JetStream. It mirrors the shape of ConsumerConfig/ProducerConfig so callers
+// can configure auth/TLS identically.
+type JSConnectionConfig struct {
+	URL      string `json:"url"`
+	AuthType string `json:"authType"`
+	Username string `json:"username"`
+	secure.DefaultCredentialConfig
+	ClientName string `json:"clientName"`
+	tlsProvider.ClientConfig
+
+	PingInterval uint `json:"pingInterval"` // seconds
+	MaxPingsOut  uint `json:"maxPingsOut"`
+	Timeout      uint `json:"timeout"` // milliseconds
+}
+
+// Validate verifies the connection config.
+func (c JSConnectionConfig) Validate() error {
+	if len(c.URL) == 0 {
+		return ErrMissingJSURL
+	}
+	if !slices.Contains(validAuthTypes, c.AuthType) {
+		return ErrInvalidAuthType
+	}
+	return nil
+}
+
+// dial opens a NATS connection using the shared connect() helper. It validates
+// the config and resolves a default client name when one is not provided.
+func (cfg *JSConnectionConfig) dial(defaultName string) (*nats.Conn, error) {
+	if cfg == nil {
+		return nil, ErrNilConfig
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	name := cfg.ClientName
+	if name == "" {
+		name = defaultName
+	}
+	return connect(connectParams{
+		URL:          cfg.URL,
+		Name:         name,
+		AuthType:     cfg.AuthType,
+		Username:     cfg.Username,
+		Cred:         cfg.DefaultCredentialConfig,
+		TLS:          cfg.ClientConfig,
+		PingInterval: cfg.PingInterval,
+		MaxPingsOut:  cfg.MaxPingsOut,
+		Timeout:      cfg.Timeout,
+	})
+}
+
+// StreamConfig mirrors the subset of jetstream.StreamConfig that is typically
+// configured from external sources. The full native type is accepted via
+// Native when callers need advanced fields.
+type StreamConfig struct {
+	Name        string        `json:"name"`
+	Description string        `json:"description"`
+	Subjects    []string      `json:"subjects"`
+	Retention   string        `json:"retention"` // "limits" | "interest" | "workqueue"
+	Storage     string        `json:"storage"`   // "file" | "memory"
+	MaxAge      time.Duration `json:"maxAge"`
+	MaxMsgs     int64         `json:"maxMsgs"`
+	MaxBytes    int64         `json:"maxBytes"`
+	Replicas    int           `json:"replicas"`
+	Duplicates  time.Duration `json:"duplicates"`
+
+	// Native allows overriding with a fully-formed jetstream.StreamConfig.
+	// When set, all other fields are ignored.
+	Native *jetstream.StreamConfig `json:"-"`
+}
+
+func (s StreamConfig) toNative() (jetstream.StreamConfig, error) {
+	if s.Native != nil {
+		return *s.Native, nil
+	}
+	if s.Name == "" {
+		return jetstream.StreamConfig{}, ErrMissingStreamName
+	}
+
+	out := jetstream.StreamConfig{
+		Name:        s.Name,
+		Description: s.Description,
+		Subjects:    s.Subjects,
+		MaxAge:      s.MaxAge,
+		MaxMsgs:     s.MaxMsgs,
+		MaxBytes:    s.MaxBytes,
+		Replicas:    s.Replicas,
+		Duplicates:  s.Duplicates,
+	}
+
+	switch s.Retention {
+	case "", "limits":
+		out.Retention = jetstream.LimitsPolicy
+	case "interest":
+		out.Retention = jetstream.InterestPolicy
+	case "workqueue":
+		out.Retention = jetstream.WorkQueuePolicy
+	default:
+		return jetstream.StreamConfig{}, ErrInvalidRetention
+	}
+
+	switch s.Storage {
+	case "", "file":
+		out.Storage = jetstream.FileStorage
+	case "memory":
+		out.Storage = jetstream.MemoryStorage
+	default:
+		return jetstream.StreamConfig{}, ErrInvalidStorage
+	}
+
+	return out, nil
+}
+
+// EnsureStream creates the stream if it does not exist, or updates it to match
+// cfg. Use AutoCreateStream=false on producers to opt out and call this
+// explicitly from setup code.
+func EnsureStream(ctx context.Context, js jetstream.JetStream, cfg StreamConfig) (jetstream.Stream, error) {
+	native, err := cfg.toNative()
+	if err != nil {
+		return nil, err
+	}
+	return js.CreateOrUpdateStream(ctx, native)
+}

--- a/provider/nats/js_consumer.go
+++ b/provider/nats/js_consumer.go
@@ -1,0 +1,404 @@
+package nats
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/oddbit-project/blueprint/log"
+)
+
+// JSConsumerConfig configures a JetStream pull consumer bound to an existing
+// stream. Durable names create a persistent consumer; leave empty for an
+// ephemeral one. FilterSubject is optional.
+type JSConsumerConfig struct {
+	JSConnectionConfig
+	StreamName    string `json:"streamName"`
+	Durable       string `json:"durable"`
+	ConsumerName  string `json:"consumerName"`
+	FilterSubject string `json:"filterSubject"`
+
+	// Pull/consumer tuning
+	AckPolicy     string        `json:"ackPolicy"` // "explicit" | "all" | "none"
+	AckWait       time.Duration `json:"ackWait"`
+	MaxDeliver    int           `json:"maxDeliver"`
+	MaxAckPending int           `json:"maxAckPending"`
+	DeliverPolicy string        `json:"deliverPolicy"` // "all" | "last" | "new"
+
+	// Native overrides the derived jetstream.ConsumerConfig if set.
+	Native *jetstream.ConsumerConfig `json:"-"`
+}
+
+// Validate verifies the consumer configuration including the embedded
+// connection config and the enum-like policy strings. It is called up front by
+// NewJSConsumer so that invalid configs fail before any network round-trips.
+func (c *JSConsumerConfig) Validate() error {
+	if err := c.JSConnectionConfig.Validate(); err != nil {
+		return err
+	}
+	if c.StreamName == "" {
+		return ErrMissingStreamName
+	}
+	if c.Native != nil {
+		return nil
+	}
+	switch c.AckPolicy {
+	case "", "explicit", "all", "none":
+	default:
+		return ErrInvalidAckPolicy
+	}
+	switch c.DeliverPolicy {
+	case "", "all", "last", "new":
+	default:
+		return ErrInvalidDeliverPolicy
+	}
+	return nil
+}
+
+// JSMessage is a thin wrapper around jetstream.Msg that keeps call sites
+// symmetric with the core-NATS Message type while still exposing ack methods.
+type JSMessage struct {
+	raw jetstream.Msg
+}
+
+// Subject returns the message subject.
+func (m JSMessage) Subject() string { return m.raw.Subject() }
+
+// Data returns the raw payload.
+func (m JSMessage) Data() []byte { return m.raw.Data() }
+
+// Headers returns the message headers.
+func (m JSMessage) Headers() nats.Header { return m.raw.Headers() }
+
+// Metadata returns JetStream delivery metadata.
+func (m JSMessage) Metadata() (*jetstream.MsgMetadata, error) { return m.raw.Metadata() }
+
+// Ack acknowledges successful processing.
+func (m JSMessage) Ack() error { return m.raw.Ack() }
+
+// Nak negatively acknowledges; the server will redeliver.
+func (m JSMessage) Nak() error { return m.raw.Nak() }
+
+// InProgress resets the ack-wait timer while still processing.
+func (m JSMessage) InProgress() error { return m.raw.InProgress() }
+
+// Term terminates the message; it will not be redelivered.
+func (m JSMessage) Term() error { return m.raw.Term() }
+
+// Raw returns the underlying jetstream.Msg for callers needing advanced APIs.
+func (m JSMessage) Raw() jetstream.Msg { return m.raw }
+
+// JSConsumerFunc is the handler type used by Consume.
+type JSConsumerFunc func(ctx context.Context, msg JSMessage) error
+
+// JSConsumer reads messages from a JetStream consumer.
+type JSConsumer struct {
+	StreamName string
+	Conn       *nats.Conn
+	JS         jetstream.JetStream
+	Stream     jetstream.Stream
+	Consumer   jetstream.Consumer
+	Logger     *log.Logger
+
+	mu        sync.Mutex
+	consCt    jetstream.ConsumeContext
+	stopWatch chan struct{}
+	closed    bool
+}
+
+// NewJSConsumer creates a pull-based JetStream consumer. The target stream
+// must already exist.
+func NewJSConsumer(cfg *JSConsumerConfig, logger *log.Logger) (*JSConsumer, error) {
+	if cfg == nil {
+		return nil, ErrNilConfig
+	}
+	// Fail fast before opening a connection or doing server round-trips.
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	conn, err := cfg.JSConnectionConfig.dial("natsJSConsumer")
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := jetstream.New(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultJSSetupTimeout)
+	stream, err := js.Stream(ctx, cfg.StreamName)
+	cancel()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	consCfg, err := buildJSConsumerConfig(cfg)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), DefaultJSSetupTimeout)
+	cons, err := stream.CreateOrUpdateConsumer(ctx, consCfg)
+	cancel()
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if logger == nil {
+		logger = NewConsumerLogger(cfg.FilterSubject, "")
+	} else {
+		logger = ConsumerLogger(logger, cfg.FilterSubject, "")
+	}
+
+	return &JSConsumer{
+		StreamName: cfg.StreamName,
+		Conn:       conn,
+		JS:         js,
+		Stream:     stream,
+		Consumer:   cons,
+		Logger:     logger,
+	}, nil
+}
+
+func buildJSConsumerConfig(cfg *JSConsumerConfig) (jetstream.ConsumerConfig, error) {
+	if cfg.Native != nil {
+		return *cfg.Native, nil
+	}
+
+	out := jetstream.ConsumerConfig{
+		Name:          cfg.ConsumerName,
+		Durable:       cfg.Durable,
+		FilterSubject: cfg.FilterSubject,
+		AckWait:       cfg.AckWait,
+		MaxDeliver:    cfg.MaxDeliver,
+		MaxAckPending: cfg.MaxAckPending,
+	}
+
+	switch cfg.AckPolicy {
+	case "", "explicit":
+		out.AckPolicy = jetstream.AckExplicitPolicy
+	case "all":
+		out.AckPolicy = jetstream.AckAllPolicy
+	case "none":
+		out.AckPolicy = jetstream.AckNonePolicy
+	default:
+		return jetstream.ConsumerConfig{}, ErrInvalidAckPolicy
+	}
+
+	switch cfg.DeliverPolicy {
+	case "", "all":
+		out.DeliverPolicy = jetstream.DeliverAllPolicy
+	case "last":
+		out.DeliverPolicy = jetstream.DeliverLastPolicy
+	case "new":
+		out.DeliverPolicy = jetstream.DeliverNewPolicy
+	default:
+		return jetstream.ConsumerConfig{}, ErrInvalidDeliverPolicy
+	}
+
+	return out, nil
+}
+
+// IsConnected reports whether the underlying connection is up and the
+// consumer has not been disconnected.
+func (c *JSConsumer) IsConnected() bool {
+	if c == nil || c.Conn == nil {
+		return false
+	}
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return false
+	}
+	return c.Conn.IsConnected()
+}
+
+// Consume starts continuous delivery; the handler is called for each message.
+// If the handler returns nil the message is Ack'd automatically; on error it
+// is Nak'd for redelivery.
+//
+// Only one concurrent Consume session is allowed per JSConsumer; calling
+// Consume while a session is already active returns ErrAlreadyConsuming. The
+// session ends when either the supplied ctx is cancelled or Disconnect() is
+// called.
+func (c *JSConsumer) Consume(ctx context.Context, handler JSConsumerFunc) error {
+	if c == nil || c.Conn == nil {
+		return ErrConsumerClosed
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return ErrConsumerClosed
+	}
+	if c.Consumer == nil {
+		c.mu.Unlock()
+		return ErrJSNoConsumer
+	}
+	if c.consCt != nil {
+		c.mu.Unlock()
+		return ErrAlreadyConsuming
+	}
+	c.mu.Unlock()
+
+	if !c.Conn.IsConnected() {
+		return ErrConsumerClosed
+	}
+
+	cc, err := c.Consumer.Consume(func(m jetstream.Msg) {
+		msg := JSMessage{raw: m}
+		if herr := handler(ctx, msg); herr != nil {
+			if c.Logger != nil {
+				c.Logger.Error(herr, "JetStream handler returned error; Nak'ing", log.KV{
+					"subject": m.Subject(),
+				})
+			}
+			if nerr := m.Nak(); nerr != nil && c.Logger != nil {
+				c.Logger.Error(nerr, "Failed to Nak JetStream message", nil)
+			}
+			return
+		}
+		if aerr := m.Ack(); aerr != nil && c.Logger != nil {
+			c.Logger.Error(aerr, "Failed to Ack JetStream message", log.KV{
+				"subject": m.Subject(),
+			})
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	stop := make(chan struct{})
+
+	c.mu.Lock()
+	if c.closed {
+		// Raced with Disconnect(): tear down the consume context we just
+		// created and report closed to the caller.
+		c.mu.Unlock()
+		cc.Stop()
+		return ErrConsumerClosed
+	}
+	c.consCt = cc
+	c.stopWatch = stop
+	c.mu.Unlock()
+
+	// Watcher goroutine: exits when either the caller's ctx is cancelled or
+	// Disconnect() closes stop. Uses cc (captured) rather than c.consCt so a
+	// subsequent Consume() after teardown can not confuse identities.
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-stop:
+		}
+		c.mu.Lock()
+		shouldStop := c.consCt == cc
+		if shouldStop {
+			c.consCt = nil
+			c.stopWatch = nil
+		}
+		c.mu.Unlock()
+		// Call Stop outside the lock to avoid holding c.mu across any
+		// potentially-blocking upstream behavior.
+		if shouldStop {
+			cc.Stop()
+		}
+	}()
+
+	return nil
+}
+
+// Fetch pulls up to batch messages, blocking up to timeout for them to arrive.
+//
+// Fetch may return a non-nil slice AND a non-nil error simultaneously when the
+// batch delivery was interrupted mid-stream (e.g. server error after some
+// messages were already received). Callers should process the returned slice
+// and handle the error separately.
+func (c *JSConsumer) Fetch(batch int, timeout time.Duration) ([]JSMessage, error) {
+	if c == nil || c.Conn == nil {
+		return nil, ErrConsumerClosed
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, ErrConsumerClosed
+	}
+	cons := c.Consumer
+	c.mu.Unlock()
+
+	if cons == nil {
+		return nil, ErrJSNoConsumer
+	}
+	if !c.Conn.IsConnected() {
+		return nil, ErrConsumerClosed
+	}
+
+	mb, err := cons.Fetch(batch, jetstream.FetchMaxWait(timeout))
+	if err != nil {
+		return nil, err
+	}
+
+	var out []JSMessage
+	for m := range mb.Messages() {
+		out = append(out, JSMessage{raw: m})
+	}
+	if err := mb.Error(); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// Disconnect stops active consumption and drains the connection. It is safe
+// to call multiple times; only the first call does work.
+func (c *JSConsumer) Disconnect() {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	sw := c.stopWatch
+	c.stopWatch = nil
+	cc := c.consCt
+	c.consCt = nil
+	conn := c.Conn
+	c.mu.Unlock()
+
+	// Release the watcher goroutine and stop the consume context outside the
+	// critical section.
+	if sw != nil {
+		close(sw)
+	}
+	if cc != nil {
+		cc.Stop()
+	}
+
+	if conn == nil || conn.IsDraining() {
+		return
+	}
+	if c.Logger != nil {
+		c.Logger.Info("Closing JetStream consumer connection", log.KV{
+			"stream": c.StreamName,
+		})
+	}
+	if err := conn.Drain(); err != nil && c.Logger != nil {
+		c.Logger.Error(err, "Error during NATS connection drain", nil)
+	}
+	conn.Close()
+	// Intentionally do not set c.Conn = nil: nats.Conn methods are safe to call
+	// after Close, IsConnected() returns false, and leaving the field set
+	// eliminates read/write races with concurrent callers.
+}

--- a/provider/nats/js_integration_test.go
+++ b/provider/nats/js_integration_test.go
@@ -1,0 +1,391 @@
+package nats
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// getTestJSProducer builds a JetStream producer bound to the suite container.
+// It auto-creates the stream so each test owns its own stream/subject pair.
+func (s *NATSIntegrationTestSuite) getTestJSProducer(streamName, subject string) *JSProducer {
+	cfg := &JSProducerConfig{
+		JSConnectionConfig: JSConnectionConfig{
+			URL:      s.natsURL,
+			AuthType: AuthTypeNone, // credentials are in URL
+		},
+		Subject: subject,
+		Stream: StreamConfig{
+			Name:     streamName,
+			Subjects: []string{subject + ".>"},
+			Storage:  "memory",
+			Replicas: 1,
+		},
+		AutoCreateStream: true,
+	}
+	p, err := NewJSProducer(cfg, s.logger)
+	require.NoError(s.T(), err, "Failed to create JS producer")
+	return p
+}
+
+// getTestJSConsumer builds a durable JetStream pull consumer for the given
+// stream. FilterSubject narrows delivery to a subject under the stream.
+func (s *NATSIntegrationTestSuite) getTestJSConsumer(streamName, durable, filterSubject string) *JSConsumer {
+	cfg := &JSConsumerConfig{
+		JSConnectionConfig: JSConnectionConfig{
+			URL:      s.natsURL,
+			AuthType: AuthTypeNone,
+		},
+		StreamName:    streamName,
+		Durable:       durable,
+		ConsumerName:  durable,
+		FilterSubject: filterSubject,
+		AckPolicy:     "explicit",
+		AckWait:       2 * time.Second,
+		MaxDeliver:    5,
+		MaxAckPending: 100,
+		DeliverPolicy: "all",
+	}
+	c, err := NewJSConsumer(cfg, s.logger)
+	require.NoError(s.T(), err, "Failed to create JS consumer")
+	return c
+}
+
+// TestJetStreamPublishConsume exercises the happy-path: auto-create stream,
+// publish, Consume via callback, and verify Ack'd delivery.
+func (s *NATSIntegrationTestSuite) TestJetStreamPublishConsume() {
+	streamName := "TEST_JS_PUBCONSUME"
+	baseSubject := "js.pubconsume"
+	subject := baseSubject + ".msg"
+
+	producer := s.getTestJSProducer(streamName, baseSubject)
+	defer producer.Disconnect()
+
+	consumer := s.getTestJSConsumer(streamName, "dur_pubconsume", subject)
+	defer consumer.Disconnect()
+
+	const total = 5
+	var received int32
+	done := make(chan struct{})
+
+	ctx, cancel := context.WithTimeout(s.ctx, 10*time.Second)
+	defer cancel()
+
+	err := consumer.Consume(ctx, func(_ context.Context, msg JSMessage) error {
+		if string(msg.Data()) == "" {
+			return fmt.Errorf("empty payload")
+		}
+		if atomic.AddInt32(&received, 1) == total {
+			close(done)
+		}
+		return nil
+	})
+	require.NoError(s.T(), err, "Consume should start")
+
+	for i := 0; i < total; i++ {
+		pubCtx, pubCancel := context.WithTimeout(s.ctx, 2*time.Second)
+		ack, err := producer.PublishMsg(pubCtx, subject, []byte(fmt.Sprintf("msg-%d", i)))
+		pubCancel()
+		require.NoError(s.T(), err, "Publish should succeed")
+		require.NotNil(s.T(), ack)
+		assert.Equal(s.T(), streamName, ack.Stream)
+	}
+
+	select {
+	case <-done:
+		assert.Equal(s.T(), int32(total), atomic.LoadInt32(&received))
+	case <-time.After(5 * time.Second):
+		s.T().Fatalf("timeout waiting for %d messages, got %d", total, atomic.LoadInt32(&received))
+	}
+}
+
+// TestJetStreamFetch exercises the one-off pull path.
+func (s *NATSIntegrationTestSuite) TestJetStreamFetch() {
+	streamName := "TEST_JS_FETCH"
+	baseSubject := "js.fetch"
+	subject := baseSubject + ".msg"
+
+	producer := s.getTestJSProducer(streamName, baseSubject)
+	defer producer.Disconnect()
+
+	consumer := s.getTestJSConsumer(streamName, "dur_fetch", subject)
+	defer consumer.Disconnect()
+
+	// Publish before fetching so the messages are already available.
+	const total = 3
+	for i := 0; i < total; i++ {
+		pubCtx, pubCancel := context.WithTimeout(s.ctx, 2*time.Second)
+		_, err := producer.PublishMsg(pubCtx, subject, []byte(fmt.Sprintf("fetch-%d", i)))
+		pubCancel()
+		require.NoError(s.T(), err)
+	}
+
+	msgs, err := consumer.Fetch(total, 3*time.Second)
+	require.NoError(s.T(), err)
+	require.Len(s.T(), msgs, total)
+
+	for _, m := range msgs {
+		assert.NotEmpty(s.T(), m.Data())
+		require.NoError(s.T(), m.Ack())
+		meta, err := m.Metadata()
+		require.NoError(s.T(), err)
+		assert.Equal(s.T(), streamName, meta.Stream)
+	}
+}
+
+// TestJetStreamRedelivery verifies that a handler returning an error causes
+// the message to be Nak'd and then redelivered up to MaxDeliver.
+func (s *NATSIntegrationTestSuite) TestJetStreamRedelivery() {
+	streamName := "TEST_JS_REDELIVER"
+	baseSubject := "js.redeliver"
+	subject := baseSubject + ".msg"
+
+	producer := s.getTestJSProducer(streamName, baseSubject)
+	defer producer.Disconnect()
+
+	consumer := s.getTestJSConsumer(streamName, "dur_redeliver", subject)
+	defer consumer.Disconnect()
+
+	var attempts int32
+	delivered := make(chan struct{}, 1)
+
+	ctx, cancel := context.WithTimeout(s.ctx, 15*time.Second)
+	defer cancel()
+
+	err := consumer.Consume(ctx, func(_ context.Context, msg JSMessage) error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 2 {
+			// first attempt: force redelivery
+			return fmt.Errorf("simulated failure attempt %d", n)
+		}
+		select {
+		case delivered <- struct{}{}:
+		default:
+		}
+		return nil
+	})
+	require.NoError(s.T(), err)
+
+	pubCtx, pubCancel := context.WithTimeout(s.ctx, 2*time.Second)
+	_, err = producer.PublishMsg(pubCtx, subject, []byte("retry-me"))
+	pubCancel()
+	require.NoError(s.T(), err)
+
+	select {
+	case <-delivered:
+		assert.GreaterOrEqual(s.T(), atomic.LoadInt32(&attempts), int32(2))
+	case <-time.After(10 * time.Second):
+		s.T().Fatalf("message not redelivered, attempts=%d", atomic.LoadInt32(&attempts))
+	}
+}
+
+// TestJetStreamEnsureStreamExplicit verifies the EnsureStream helper path when
+// AutoCreateStream is left false on the producer.
+func (s *NATSIntegrationTestSuite) TestJetStreamEnsureStreamExplicit() {
+	streamName := "TEST_JS_EXPLICIT"
+	baseSubject := "js.explicit"
+	subject := baseSubject + ".msg"
+
+	// First, create the stream via a producer with AutoCreateStream so that a
+	// second, non-creating producer can find it.
+	bootstrap := s.getTestJSProducer(streamName, baseSubject)
+	bootstrap.Disconnect()
+
+	cfg := &JSProducerConfig{
+		JSConnectionConfig: JSConnectionConfig{
+			URL:      s.natsURL,
+			AuthType: AuthTypeNone,
+		},
+		Subject: subject,
+		Stream: StreamConfig{
+			Name: streamName,
+		},
+		AutoCreateStream: false,
+	}
+	p, err := NewJSProducer(cfg, s.logger)
+	require.NoError(s.T(), err)
+	defer p.Disconnect()
+
+	require.NotNil(s.T(), p.Stream, "Stream should have been looked up")
+
+	pubCtx, pubCancel := context.WithTimeout(s.ctx, 2*time.Second)
+	ack, err := p.PublishMsg(pubCtx, subject, []byte("hello"))
+	pubCancel()
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), streamName, ack.Stream)
+}
+
+// TestJetStreamMissingStreamName guards the validation path.
+func TestJetStreamMissingStreamName(t *testing.T) {
+	_, err := NewJSConsumer(&JSConsumerConfig{
+		JSConnectionConfig: JSConnectionConfig{
+			URL:      "nats://localhost:4222",
+			AuthType: AuthTypeNone,
+		},
+	}, nil)
+	assert.ErrorIs(t, err, ErrMissingStreamName)
+}
+
+// TestJSConsumerConfigValidate covers the fast-fail validation added to avoid
+// opening a connection and performing stream lookups on invalid configs.
+func TestJSConsumerConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     JSConsumerConfig
+		wantErr error
+	}{
+		{
+			name:    "missing URL",
+			cfg:     JSConsumerConfig{},
+			wantErr: ErrMissingJSURL,
+		},
+		{
+			name: "invalid auth type",
+			cfg: JSConsumerConfig{
+				JSConnectionConfig: JSConnectionConfig{URL: "nats://x", AuthType: "bogus"},
+			},
+			wantErr: ErrInvalidAuthType,
+		},
+		{
+			name: "missing stream",
+			cfg: JSConsumerConfig{
+				JSConnectionConfig: JSConnectionConfig{URL: "nats://x", AuthType: AuthTypeNone},
+			},
+			wantErr: ErrMissingStreamName,
+		},
+		{
+			name: "invalid ack policy",
+			cfg: JSConsumerConfig{
+				JSConnectionConfig: JSConnectionConfig{URL: "nats://x", AuthType: AuthTypeNone},
+				StreamName:         "S",
+				AckPolicy:          "whatever",
+			},
+			wantErr: ErrInvalidAckPolicy,
+		},
+		{
+			name: "invalid deliver policy",
+			cfg: JSConsumerConfig{
+				JSConnectionConfig: JSConnectionConfig{URL: "nats://x", AuthType: AuthTypeNone},
+				StreamName:         "S",
+				DeliverPolicy:      "sometime",
+			},
+			wantErr: ErrInvalidDeliverPolicy,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			assert.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestJSProducerConfigValidate covers producer-side fast-fail validation.
+func TestJSProducerConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     JSProducerConfig
+		wantErr error
+	}{
+		{
+			name:    "missing URL",
+			cfg:     JSProducerConfig{},
+			wantErr: ErrMissingJSURL,
+		},
+		{
+			name: "missing subject",
+			cfg: JSProducerConfig{
+				JSConnectionConfig: JSConnectionConfig{URL: "nats://x", AuthType: AuthTypeNone},
+			},
+			wantErr: ErrMissingProducerTopic,
+		},
+		{
+			name: "auto create with bad retention",
+			cfg: JSProducerConfig{
+				JSConnectionConfig: JSConnectionConfig{URL: "nats://x", AuthType: AuthTypeNone},
+				Subject:            "s",
+				Stream:             StreamConfig{Name: "S", Retention: "bogus"},
+				AutoCreateStream:   true,
+			},
+			wantErr: ErrInvalidRetention,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			assert.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestJetStreamConsumeTwiceRejected verifies that a second Consume() call on
+// the same JSConsumer is rejected with ErrAlreadyConsuming rather than
+// silently overwriting the first consume context.
+func (s *NATSIntegrationTestSuite) TestJetStreamConsumeTwiceRejected() {
+	streamName := "TEST_JS_CONSUMETWICE"
+	baseSubject := "js.twice"
+	subject := baseSubject + ".msg"
+
+	producer := s.getTestJSProducer(streamName, baseSubject)
+	defer producer.Disconnect()
+
+	consumer := s.getTestJSConsumer(streamName, "dur_twice", subject)
+	defer consumer.Disconnect()
+
+	ctx1, cancel1 := context.WithCancel(s.ctx)
+	defer cancel1()
+
+	err := consumer.Consume(ctx1, func(_ context.Context, _ JSMessage) error { return nil })
+	require.NoError(s.T(), err)
+
+	err = consumer.Consume(s.ctx, func(_ context.Context, _ JSMessage) error { return nil })
+	assert.ErrorIs(s.T(), err, ErrAlreadyConsuming)
+
+	// After cancelling the first context the watcher goroutine should release
+	// consCt, allowing a subsequent Consume() to succeed. Poll briefly for
+	// the teardown since it runs asynchronously.
+	cancel1()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err = consumer.Consume(s.ctx, func(_ context.Context, _ JSMessage) error { return nil })
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(s.T(), err, "second Consume after first ctx cancel should succeed")
+}
+
+// TestJetStreamConsumeThenDisconnect verifies that Disconnect() cleanly stops
+// an active Consume session even when the caller's context is a non-cancellable
+// background context (H2 regression guard — without the stop channel, the
+// watcher goroutine would leak).
+func (s *NATSIntegrationTestSuite) TestJetStreamConsumeThenDisconnect() {
+	streamName := "TEST_JS_DISCONNECT"
+	baseSubject := "js.disconnect"
+	subject := baseSubject + ".msg"
+
+	producer := s.getTestJSProducer(streamName, baseSubject)
+	defer producer.Disconnect()
+
+	consumer := s.getTestJSConsumer(streamName, "dur_disconnect", subject)
+
+	err := consumer.Consume(context.Background(), func(_ context.Context, _ JSMessage) error {
+		return nil
+	})
+	require.NoError(s.T(), err)
+
+	// Disconnect immediately — the watcher goroutine should be released via
+	// the internal stop channel even though the background context never
+	// cancels.
+	consumer.Disconnect()
+	assert.False(s.T(), consumer.IsConnected())
+
+	// Second Disconnect should be a no-op.
+	consumer.Disconnect()
+}

--- a/provider/nats/js_producer.go
+++ b/provider/nats/js_producer.go
@@ -1,0 +1,220 @@
+package nats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/oddbit-project/blueprint/log"
+)
+
+// JSProducerConfig configures a JetStream producer. Subject is the default
+// subject used by Publish/PublishJSON. Stream describes the stream to target;
+// when AutoCreateStream is true the stream is created or updated on startup.
+type JSProducerConfig struct {
+	JSConnectionConfig
+	Subject          string       `json:"subject"`
+	Stream           StreamConfig `json:"stream"`
+	AutoCreateStream bool         `json:"autoCreateStream"`
+}
+
+// Validate verifies the producer configuration including the embedded
+// connection config. It is called up front by NewJSProducer so invalid configs
+// fail before any network round-trips.
+func (c *JSProducerConfig) Validate() error {
+	if err := c.JSConnectionConfig.Validate(); err != nil {
+		return err
+	}
+	if c.Subject == "" {
+		return ErrMissingProducerTopic
+	}
+	if c.AutoCreateStream {
+		if _, err := c.Stream.toNative(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// JSProducer publishes messages to a JetStream stream with server-side acks.
+//
+// Stream is the handle resolved (or created) during construction. It is
+// exposed as a public field for callers that want to inspect or manage stream
+// state; it is not used internally by Publish operations.
+type JSProducer struct {
+	Subject string
+	Conn    *nats.Conn
+	JS      jetstream.JetStream
+	Stream  jetstream.Stream
+	Logger  *log.Logger
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// NewJSProducer creates a JetStream producer.
+func NewJSProducer(cfg *JSProducerConfig, logger *log.Logger) (*JSProducer, error) {
+	if cfg == nil {
+		return nil, ErrNilConfig
+	}
+	// Fail fast before opening a connection.
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	conn, err := cfg.JSConnectionConfig.dial("natsJSProducer")
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := jetstream.New(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if logger == nil {
+		logger = NewProducerLogger(cfg.Subject)
+	} else {
+		logger = ProducerLogger(logger, cfg.Subject)
+	}
+
+	var stream jetstream.Stream
+	if cfg.AutoCreateStream {
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultJSSetupTimeout)
+		stream, err = EnsureStream(ctx, js, cfg.Stream)
+		cancel()
+		if err != nil {
+			logger.Error(err, "Failed to ensure JetStream stream", log.KV{
+				"stream": cfg.Stream.Name,
+			})
+			conn.Close()
+			return nil, err
+		}
+	} else if cfg.Stream.Name != "" {
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultJSSetupTimeout)
+		stream, err = js.Stream(ctx, cfg.Stream.Name)
+		cancel()
+		if err != nil {
+			logger.Error(err, "Failed to look up JetStream stream", log.KV{
+				"stream": cfg.Stream.Name,
+			})
+			conn.Close()
+			return nil, err
+		}
+	}
+
+	return &JSProducer{
+		Subject: cfg.Subject,
+		Conn:    conn,
+		JS:      js,
+		Stream:  stream,
+		Logger:  logger,
+	}, nil
+}
+
+// IsConnected reports whether the underlying connection is up and the
+// producer has not been disconnected.
+func (p *JSProducer) IsConnected() bool {
+	if p == nil || p.Conn == nil {
+		return false
+	}
+	p.mu.Lock()
+	closed := p.closed
+	p.mu.Unlock()
+	if closed {
+		return false
+	}
+	return p.Conn.IsConnected()
+}
+
+// Disconnect drains and closes the underlying connection. Safe to call
+// multiple times.
+func (p *JSProducer) Disconnect() {
+	if p == nil {
+		return
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	p.closed = true
+	conn := p.Conn
+	p.mu.Unlock()
+
+	if conn == nil || conn.IsDraining() {
+		return
+	}
+	if p.Logger != nil {
+		p.Logger.Info("Closing JetStream producer connection", log.KV{
+			"subject": p.Subject,
+		})
+	}
+	if err := conn.Drain(); err != nil && p.Logger != nil {
+		p.Logger.Error(err, "Error during NATS connection drain", nil)
+	}
+	conn.Close()
+	// Intentionally do not set p.Conn = nil; see note in JSConsumer.Disconnect.
+}
+
+// Publish publishes data to the configured subject and waits for the server
+// ack.
+func (p *JSProducer) Publish(ctx context.Context, data []byte) (*jetstream.PubAck, error) {
+	return p.PublishMsg(ctx, p.Subject, data)
+}
+
+// PublishMsg publishes data to an explicit subject.
+func (p *JSProducer) PublishMsg(ctx context.Context, subject string, data []byte) (*jetstream.PubAck, error) {
+	if p == nil {
+		return nil, errors.New("publisher is nil")
+	}
+	if !p.IsConnected() {
+		return nil, ErrProducerClosed
+	}
+	ack, err := p.JS.Publish(ctx, subject, data)
+	if err != nil {
+		if p.Logger != nil {
+			p.Logger.Error(err, "Failed to publish JetStream message", log.KV{
+				"subject":      subject,
+				"message_size": len(data),
+			})
+		}
+		return nil, err
+	}
+	return ack, nil
+}
+
+// PublishJSON marshals data as JSON and publishes to the configured subject.
+func (p *JSProducer) PublishJSON(ctx context.Context, data interface{}) (*jetstream.PubAck, error) {
+	payload, err := json.Marshal(data)
+	if err != nil {
+		if p.Logger != nil {
+			p.Logger.Error(err, "Failed to marshal JSON for JetStream publish", nil)
+		}
+		return nil, err
+	}
+	return p.Publish(ctx, payload)
+}
+
+// PublishAsync publishes without waiting for ack in-line; the returned
+// PubAckFuture exposes a channel for the ack. The caller-supplied context is
+// checked up front (the underlying jetstream async publish has no ctx
+// parameter), so callers should also select on the future's channel for
+// cancellation after dispatch.
+func (p *JSProducer) PublishAsync(ctx context.Context, subject string, data []byte) (jetstream.PubAckFuture, error) {
+	if p == nil {
+		return nil, errors.New("publisher is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !p.IsConnected() {
+		return nil, ErrProducerClosed
+	}
+	return p.JS.PublishAsync(subject, data)
+}

--- a/provider/nats/producer.go
+++ b/provider/nats/producer.go
@@ -73,78 +73,35 @@ func NewProducer(cfg *ProducerConfig, logger *log.Logger) (*Producer, error) {
 		return nil, err
 	}
 
-	var key []byte
-	var credential *secure.Credential
-	var password string
-	var err error
-
-	switch cfg.AuthType {
-	case AuthTypeToken, AuthTypeBasic:
-		key, err = secure.GenerateKey()
-		if err != nil {
-			return nil, err
-		}
-		if credential, err = secure.CredentialFromConfig(cfg.DefaultCredentialConfig, key, true); err != nil {
-			return nil, err
-		}
-		password, err = credential.Get()
-		if err != nil {
-			return nil, err
-		}
-
-	}
-
-	// Configure connection options
 	if len(cfg.ProducerName) == 0 {
 		cfg.ProducerName = "natsProducer"
 	}
-	opts := nats.Options{
-		Url:            cfg.URL,
-		AllowReconnect: true,
-		MaxReconnect:   DefaultConnectRetry,
-		ReconnectWait:  DefaultTimeout,
-		Name:           cfg.ProducerName,
-	}
-
-	// Apply authentication
-	switch cfg.AuthType {
-	case AuthTypeBasic:
-		opts.User = cfg.Username
-		opts.Password = password
-	case AuthTypeToken:
-		opts.Token = password
-	}
-
-	// Apply TLS settings
-	if tls, err := cfg.TLSConfig(); err != nil {
-		return nil, err
-	} else if tls != nil {
-		opts.TLSConfig = tls
-	}
-
-	// Apply additional options
-	cfg.ProducerOptions.ApplyOptions(&opts)
 
 	// Create logger if not provided
 	if logger == nil {
 		logger = NewProducerLogger(cfg.Subject)
 	} else {
-		ProducerLogger(logger, cfg.Subject)
+		logger = ProducerLogger(logger, cfg.Subject)
 	}
 
-	// Connect to NATS
-	conn, err := opts.Connect()
+	// Connect to NATS via shared helper
+	conn, err := connect(connectParams{
+		URL:          cfg.URL,
+		Name:         cfg.ProducerName,
+		AuthType:     cfg.AuthType,
+		Username:     cfg.Username,
+		Cred:         cfg.DefaultCredentialConfig,
+		TLS:          cfg.ClientConfig,
+		PingInterval: cfg.ProducerOptions.PingInterval,
+		MaxPingsOut:  cfg.ProducerOptions.MaxPingsOut,
+		Timeout:      cfg.ProducerOptions.Timeout,
+	})
 	if err != nil {
 		logger.Error(err, "Failed to connect to NATS", log.KV{
 			"url":     cfg.URL,
 			"subject": cfg.Subject,
 		})
 		return nil, err
-	}
-
-	// Clean up credentials from memory if used
-	if credential != nil {
-		credential.Clear()
 	}
 
 	return &Producer{


### PR DESCRIPTION
Adds JSProducer/JSConsumer for JetStream persistent streaming with StreamConfig wrapper, up-front Validate on both config types, auto Ack/Nak on handler result, single-session Consume guard, and Fetch for pull-style batching. Extracts shared NATS connection logic into connection.go so core and JS clients share one path; silently fixes a pre-existing bug where ConsumerConfig token auth sent an empty token. Also fixes pre-existing discarded ConsumerLogger/ProducerLogger return values, tightens credential hygiene via defer Clear, and moves cc.Stop() calls out of the consumer mutex. Integration tests now run the nats container with -js and cover publish/consume, fetch, redelivery, explicit stream lookup, double-Consume rejection, and Disconnect-while-consuming.